### PR TITLE
default /available to season 1 if none given for tv

### DIFF
--- a/src/commands/available.ts
+++ b/src/commands/available.ts
@@ -23,9 +23,9 @@ export class AvailableCommand extends Command {
 
       if (type === 'tv') {
         const seasonOption = interaction.options.getInteger('season', false);
-        season = seasonOption !== null ? seasonOption : 1; 
+        season = seasonOption !== null ? seasonOption : 1;
         episode = interaction.options.getInteger('episode') ?? undefined;
-      } 
+      }
 
       const scrapeMedia = transformSearchResultToScrapeMedia(type, result, season, episode);
 

--- a/src/commands/available.ts
+++ b/src/commands/available.ts
@@ -22,9 +22,10 @@ export class AvailableCommand extends Command {
       let episode: number | undefined;
 
       if (type === 'tv') {
-        season = interaction.options.getInteger('season') ?? undefined;
+        const seasonOption = interaction.options.getInteger('season', false);
+        season = seasonOption !== null ? seasonOption : 1; 
         episode = interaction.options.getInteger('episode') ?? undefined;
-      }
+      } 
 
       const scrapeMedia = transformSearchResultToScrapeMedia(type, result, season, episode);
 


### PR DESCRIPTION
defaults to s01 instead of s00 as it sometimes does, but still lets user pass in "0" if so desired

tested:tm: