### PR TITLE
chore: fix typo in instances command

### DIFF
--- a/src/tags.toml
+++ b/src/tags.toml
@@ -80,7 +80,7 @@ content = """
 # Why is movie-web.app down/having an issue?
 The old official instance has been taken down. You can read more [here](https://discord.com/channels/871713465100816424/1116430057922121760/1210364442601193552) and in <#871715205686636564>
 You may still be seeing a cached version in your browser, but it is outdated, unsupported and will dissapear soon.
-To keep using on using movie-web, switch to a [Community Instance](<https://movie-web.github.io/docs/instances>) or [self-host]<https://movie-web.github.io/docs/self-hosting/hosting-intro>)
+To keep using on using movie-web, switch to a [Community Instance](<https://movie-web.github.io/docs/instances>) or [self-host](<https://movie-web.github.io/docs/self-hosting/hosting-intro>)
 """
 
 [dns]


### PR DESCRIPTION
adds the missing `(` so that markdown actually markdowns